### PR TITLE
:construction: Enables Alpine Version Selection

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,14 +6,17 @@ export const myPlugin = () => {
   return {
     name: 'my-plugin',
     resolveId(id: string) {
-      if (id.endsWith('?dlx')) {
+      if (id.includes('?dlx')) {
         return id;
       }
     },
     async load(id: string) {
-      if (id.endsWith('?dlx')) {
+      if (id.includes('?dlx')) {
         const res = await fetch('https://' + id);
-        return res.text();
+        const text = await res.text();
+        if (id.includes('&json'))
+          return `export default JSON.parse(${JSON.stringify(text)})`;
+        return text;
       }
     },
   };

--- a/www/src/components/draggablePartition.ts
+++ b/www/src/components/draggablePartition.ts
@@ -11,7 +11,8 @@ Alpine.directive('partition', (el) => {
       this.dragging = true;
     },
     mouseup(e: PointerEvent) {
-      if (this.dragging) e.preventDefault();
+      if (!this.dragging) return;
+      e.preventDefault();
       console.log('ending drag');
       this.dragging = false;
     },

--- a/www/src/components/editor.ts
+++ b/www/src/components/editor.ts
@@ -28,8 +28,10 @@ Alpine.data('editor', () => ({
     settings: {
       typescript: Alpine.query(false).as('ts').encoding(booleanNumber),
       tailwind: Alpine.query(false).as('tw').encoding(booleanNumber),
+      version: Alpine.query<`${number}.${number}.${number}`>('3.13.5').as('v'),
     },
   },
+  alpineVersions: [] as string[],
   value: {
     html: Alpine.query(starterHTML).encoding(base64URL).as('html'),
     typescript: Alpine.query(starterScript).encoding(base64URL).as('script'),
@@ -58,6 +60,10 @@ Alpine.data('editor', () => ({
     this.sandbox = sandbox;
     console.log('initializing sandbox');
     this.sandbox.call.log('Hello from Alpine!');
+    await effectPromise(async () => {
+      console.log('loading Alpine version', this.config.settings.version);
+      await this.sandbox.call.loadAlpine(this.config.settings.version);
+    });
     await Promise.all([
       effectPromise(async () => {
         console.log('Loading Tailwind');
@@ -82,6 +88,11 @@ Alpine.data('editor', () => ({
       }),
     ]);
     this.sandbox.call.start();
+    const alpineRegistry = await import(
+      'registry.npmjs.com/alpinejs?dlx&json'
+    ).then((mod) => mod.default);
+    console.log(alpineRegistry);
+    this.alpineVersions = Object.keys(alpineRegistry.versions).reverse();
   },
   async prettify() {
     for (const type of [Language.HTML, Language.TYPESCRIPT]) {

--- a/www/src/lib/lazyModules/alpinePlugins.ts
+++ b/www/src/lib/lazyModules/alpinePlugins.ts
@@ -1,20 +1,27 @@
-export const gatherPlugins = (pluginlist: CorePlugins[]) => {
+const importFromESM = (
+  name: string,
+  version: `${number}.${number}.${number}`,
+) => import(/* @vite-ignore */ `https://esm.sh/@alpinejs/${name}@${version}`);
+export const gatherPlugins = (
+  pluginlist: CorePlugins[],
+  version: `${number}.${number}.${number}`,
+) => {
   const plugins = pluginlist.map((plugin) => {
     switch (Number(plugin)) {
       case CorePlugins.Anchor:
-        return import('@alpinejs/anchor');
+        return importFromESM('anchor', version);
       case CorePlugins.Collapse:
-        return import('@alpinejs/collapse');
+        return importFromESM('collapse', version);
       case CorePlugins.Focus:
-        return import('@alpinejs/focus');
+        return importFromESM('focus', version);
       case CorePlugins.Intersect:
-        return import('@alpinejs/intersect');
+        return importFromESM('intersect', version);
       case CorePlugins.Mask:
-        return import('@alpinejs/mask');
+        return importFromESM('mask', version);
       case CorePlugins.Morph:
-        return import('@alpinejs/morph');
+        return importFromESM('morph', version);
       case CorePlugins.Persist:
-        return import('@alpinejs/persist');
+        return importFromESM('persist', version);
     }
     return Promise.resolve({ default: () => {} });
   });

--- a/www/src/lib/postmessageRPC.ts
+++ b/www/src/lib/postmessageRPC.ts
@@ -63,21 +63,25 @@ const waitForResponse = <T>(
   timeout: number = 0,
 ): Promise<T> => {
   return new Promise<T>((res) => {
+    let timeoutid;
     const handler = (event: MessageEvent<ActionResponse>) => {
       if (event.source === source && event.data.id === id) {
         window.removeEventListener('message', handler);
+        clearTimeout(timeoutid);
         res(event.data.value as T);
       }
     };
     window.addEventListener('message', handler);
     if (timeout)
-      setTimeout(() => {
+      timeoutid = setTimeout(() => {
         console.log('timing out');
         window.removeEventListener('message', handler);
         res(undefined);
       }, timeout);
   });
 };
+
+// eslint
 
 interface Action<A> {
   id: number;

--- a/www/src/play.html
+++ b/www/src/play.html
@@ -233,57 +233,64 @@
               x-init="registerEditor($el, 'typescript')"></div>
           </div>
           <div
-            class="border-t border-gray-200 dark:border-white/10 flex-auto -mb-2 text-slate-100 flex flex-col gap-2 py-3 px-4"
+            class="border-t border-gray-200 dark:border-white/10 flex-auto -mb-2 text-slate-100 flex flex-col gap-4 py-3 px-4 accent-indigo-800"
             x-show="panel === 'config'">
             <h2 class="sr-only">Configuration Options</h2>
-            <h3>Settings</h3>
-            <ul class="ml-3">
-              <li>
-                <label class="flex gap-4">
-                  <input
-                    type="checkbox"
-                    name="setting"
-                    x-model="config.settings.typescript" />
-                  <code>Use TypeScript</code>
-                </label>
-              </li>
-              <li>
-                <label class="flex gap-4">
-                  <input
-                    type="checkbox"
-                    name="setting"
-                    x-model="config.settings.tailwind" />
-                  <code>Use Tailwind</code>
-                </label>
-              </li>
-            </ul>
-            <label class="flex gap-4">
-              <code> Alpine Version </code>
+            <div class="flex flex-col gap-2">
+              <h3>Settings</h3>
+              <ul class="ml-3">
+                <li>
+                  <label class="flex gap-4">
+                    <input
+                      type="checkbox"
+                      name="setting"
+                      x-model="config.settings.typescript" />
+                    <code>Use TypeScript</code>
+                  </label>
+                </li>
+                <li>
+                  <label class="flex gap-4">
+                    <input
+                      type="checkbox"
+                      name="setting"
+                      x-model="config.settings.tailwind" />
+                    <code>Use Tailwind</code>
+                  </label>
+                </li>
+              </ul>
+            </div>
+            <label class="flex flex-col gap-2">
+              <h3>Alpine Version *</h3>
               <select
                 x-model="config.settings.version"
-                class="bg-slate-700 px-2 py-1">
+                class="bg-slate-800 px-2 py-1 max-w-max min-w-[12ch] font-mono ml-3">
                 <template x-for="(version,i) in alpineVersions" :key="version">
                   <option
                     x-text="i ? version : `Latest (${version})`"
                     :value="version"></option>
                 </template>
               </select>
+              <span class="text-xs text-slate-300/90 tracking-wide ml-3">
+                * Most versions older version will probably not work
+              </span>
             </label>
-            <h3>Core Plugins</h3>
-            <ul class="ml-3">
-              <template x-for="plugin in CorePlugins" :key="plugin[1]">
-                <li>
-                  <label class="flex gap-4">
-                    <input
-                      type="checkbox"
-                      name="plugin"
-                      x-model="config.plugins"
-                      :value="plugin[1]" />
-                    <code x-text="plugin[0]">Plugin Not Found</code>
-                  </label>
-                </li>
-              </template>
-            </ul>
+            <div class="flex flex-col gap-2">
+              <h3>Core Plugins</h3>
+              <ul class="ml-3">
+                <template x-for="plugin in CorePlugins" :key="plugin[1]">
+                  <li>
+                    <label class="flex gap-4">
+                      <input
+                        type="checkbox"
+                        name="plugin"
+                        x-model="config.plugins"
+                        :value="plugin[1]" />
+                      <code x-text="plugin[0]">Plugin Not Found</code>
+                    </label>
+                  </li>
+                </template>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/www/src/play.html
+++ b/www/src/play.html
@@ -257,6 +257,18 @@
                 </label>
               </li>
             </ul>
+            <label class="flex gap-4">
+              <code> Alpine Version </code>
+              <select
+                x-model="config.settings.version"
+                class="bg-slate-700 px-2 py-1">
+                <template x-for="(version,i) in alpineVersions" :key="version">
+                  <option
+                    x-text="i ? version : `Latest (${version})`"
+                    :value="version"></option>
+                </template>
+              </select>
+            </label>
             <h3>Core Plugins</h3>
             <ul class="ml-3">
               <template x-for="plugin in CorePlugins" :key="plugin[1]">

--- a/www/src/types.d.ts
+++ b/www/src/types.d.ts
@@ -27,3 +27,8 @@ declare module 'esbuild-wasm/esbuild.wasm?url' {
   const esbuildWASM: string;
   export default esbuildWASM;
 }
+
+declare module 'registry.npmjs.com/alpinejs?dlx&json' {
+  const alpineRegistry: { versions: Record<string, unknown> };
+  export default alpineRegistry;
+}


### PR DESCRIPTION
Barely works, but it DOES work.

Issues:
- Plugins are not available in all versions, so that needs to be deconflicted/indicated (should it allow loading of the oldest version of a plugin when Alpine version is older than plugin?)
- If sandbox reloads, editor keeps applying additional effects. Move effects out of initialization.