### PR TITLE
:sparkles: Adds support for Sort plugin

### DIFF
--- a/www/src/lib/lazyModules/alpinePlugins.ts
+++ b/www/src/lib/lazyModules/alpinePlugins.ts
@@ -36,4 +36,5 @@ export enum CorePlugin {
   Mask = 1 << 4,
   Morph = 1 << 5,
   Persist = 1 << 6,
+  Sort = 1 << 7,
 }

--- a/www/src/play/playSandbox.ts
+++ b/www/src/play/playSandbox.ts
@@ -79,7 +79,7 @@ const actions = {
 
     state.Alpine = await import(
       /* @vite-ignore */
-      script.url
+      script.bundleUrl
     ).then((mod) => mod.default);
     if (!state.alpineStarted) return;
     state.Alpine?.startObservingMutations();

--- a/www/src/plugins/vite/AlpinePackageData.ts
+++ b/www/src/plugins/vite/AlpinePackageData.ts
@@ -11,6 +11,7 @@ const ALPINE_PACKAGES = [
   '@alpinejs/focus',
   '@alpinejs/collapse',
   '@alpinejs/anchor',
+  '@alpinejs/sort',
 ];
 
 const getPackageData = async (): Promise<PackageInfo[]> => {


### PR DESCRIPTION
+ Uses bundled URL to avoid Alpine instance issues (like trying to re-add persist.